### PR TITLE
build-single.xml: Error building module dependencies

### DIFF
--- a/build-single.xml
+++ b/build-single.xml
@@ -289,7 +289,7 @@
 								<fileset dir="${module.input.lib}" includes="*.jar" />
 							</path>
 							<sequential>
-								<var name="module.libs.path" value="${module.libs.path}:${module.input.lib}/@{archive}" />
+								<var name="module.libs.path" value="${module.libs.path}:@{archive}" />
 							</sequential>
 						</for>
 					</then>


### PR DESCRIPTION
The current `build-single.xml` script goes through the list of jar files in the `${module.input.lib}` dir and builds an erroneous `${module.libs.path}`:

```
${module.libs.path}:${module.input.lib}/@{archive}
```
- `module.libs.path` contains the concatenated path
- `module.input.lib` is the **absolute** path to the module input lib directory
- `@{archive}` is the **absolute** path to the jar file

Thus, every jar is build with the dir fragment duplicated. It does not work!
