### PR TITLE
build-single.xml: outdated dependencies for opencms tasks

### DIFF
--- a/build-single.xml
+++ b/build-single.xml
@@ -30,7 +30,11 @@
 
 	<taskdef resource="net/sf/antcontrib/antlib.xml" loaderref="contrib">
 		<classpath>
-			<pathelement location="${opencms.input.libs.compile}/ant-contrib-1.0b1.jar" />
+			<pathelement location="${opencms.input.libs.compile}/ant-opencms-1.2.jar" />
+			<pathelement location="${opencms.input.libs.runtime}/commons-digester-1.8.jar" />
+			<pathelement location="${opencms.input.libs.runtime}/commons-collections-3.2.1.jar" />
+			<pathelement location="${opencms.input.libs.runtime}/commons-logging-1.1.1.jar" />
+			<pathelement location="${opencms.input.libs.runtime}/commons-beanutils-1.8.0.jar" />
 		</classpath>
 	</taskdef>
 


### PR DESCRIPTION
`ant-opencms-1.1.jar` is outdated. Current `ant-opencms-1.2.jar` pulls dependencies from `commons-digester-1.8.jar`, `commons-collections-3.2.1.jar`, `commons-logging-1.1.1.jar`, `commons-beanutils-1.8.0.jar`. The taskdef:

```
<taskdef resource="org/opencms/util/ant/taskdefs.properties" loaderref="opencms">...</taskdef>
```

should be fixed accordingly.
