### PR TITLE
build.xml: Outdated dependency

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -25,7 +25,7 @@
 
 	<taskdef resource="org/opencms/util/ant/taskdefs.properties" loaderref="opencms">
 		<classpath>
-			<pathelement location="${opencms.input}/lib/compile/ant-opencms-1.1.jar" />
+			<pathelement location="${opencms.input}/lib/compile/ant-opencms-1.2.jar" />
 		</classpath>
 	</taskdef>
 


### PR DESCRIPTION
I must obviously be missing something here. The build.xml refers to ant-opencms-1.1.jar, but the current opencms-core is being packaged with "ant-opencms-1.2.jar" (https://github.com/alkacon/opencms-core/blob/master/lib/compile/ant-opencms-1.2.jar) since at least 9 months ago!:

> mMoossen 9 months ago removed core dependencies in ant-opencms-1.2.jar.

Current build.xml doesn't compile and fails with:

> [...]/src/opencms-alkacon/alkacon-oamp/build.xml:63: Problem: failed to create task or type selectionprompt
> Cause: The name is undefined.
> Action: Check the spelling.
> Action: Check that any custom tasks/types have been declared.
> Action: Check that any <presetdef>/<macrodef> declarations have taken place.

Is anyone using this build-script?
