### PR TITLE
Bugfix for <Path /> traversal in Web Optimization module

### DIFF
--- a/com.alkacon.opencms.weboptimization/src/com/alkacon/opencms/weboptimization/CmsOptimizationBean.java
+++ b/com.alkacon.opencms.weboptimization/src/com/alkacon/opencms/weboptimization/CmsOptimizationBean.java
@@ -60,6 +60,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.jsp.PageContext;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 
 /**
@@ -483,9 +484,16 @@ public abstract class CmsOptimizationBean extends CmsJspActionElement {
      */
     protected List<CmsResource> resolveResource(CmsObject cms, String path, String ext) throws CmsException {
 
+        List<CmsResource> resorces = new ArrayList<CmsResource>();
+        
+        // An empty path is most probably a bug/unintentionally included. Ignoring it.
+        if (StringUtils.isBlank(path)) {
+            LOG.warn(Messages.get().getBundle().key(Messages.LOG_WARN_RESOLVE_EMPTY_PATH_1, cms.getRequestContext().getUri()));
+            return resorces;
+        }
+        
         CmsResource res = cms.readResource(path);
 
-        List<CmsResource> resorces = new ArrayList<CmsResource>();
         if (res.isFolder()) {
             // if folder, get all files with the given extension in the folder
             List<CmsResource> files = cms.readResources(path, CmsResourceFilter.DEFAULT_FILES);

--- a/com.alkacon.opencms.weboptimization/src/com/alkacon/opencms/weboptimization/Messages.java
+++ b/com.alkacon.opencms.weboptimization/src/com/alkacon/opencms/weboptimization/Messages.java
@@ -49,6 +49,9 @@ public final class Messages extends A_CmsMessageBundle {
     /** Message constant for key in the resource bundle. */
     public static final String LOG_WARN_NOTHING_TO_PROCESS_1 = "LOG_WARN_NOTHING_TO_PROCESS_1";
 
+    /** Message constant for key in the resource bundle. */
+    public static final String LOG_WARN_RESOLVE_EMPTY_PATH_1 = "LOG_WARN_RESOLVE_EMPTY_PATH_1";
+
     /** Name of the used resource bundle. */
     private static final String BUNDLE_NAME = "com.alkacon.opencms.weboptimization.messages";
 

--- a/com.alkacon.opencms.weboptimization/src/com/alkacon/opencms/weboptimization/messages.properties
+++ b/com.alkacon.opencms.weboptimization/src/com/alkacon/opencms/weboptimization/messages.properties
@@ -1,2 +1,3 @@
 LOG_WARN_NOTHING_TO_PROCESS_1			= Nothing to process for entry {0}
 ERR_NOT_SUPPORTED_RESOURCE_TYPE_2		= Not supported resource type {1} of given resource {0}
+LOG_WARN_RESOLVE_EMPTY_PATH_1           =Tried to include an empty path while optimizing {0}. Ignoring entry.


### PR DESCRIPTION
This prevents the web optimization module from traversing the entire
project's VFS if an empty <Path /> is rendered on the Online project.

This is a fix for Issue #14.
