### PR TITLE
Fix opencms taskdef in build-single.xml

### DIFF
--- a/build-single.xml
+++ b/build-single.xml
@@ -36,7 +36,16 @@
 
 	<taskdef resource="org/opencms/util/ant/taskdefs.properties" loaderref="opencms">
 		<classpath>
-			<pathelement location="${opencms.input.libs.compile}/ant-opencms-1.1.jar" />
+			<pathelement location="${opencms.input.libs.compile}/ant.jar" />
+			<pathelement location="${opencms.input.libs.compile}/ant-contrib-1.0b1.jar" />
+			<pathelement location="${opencms.input.libs.compile}/ant-opencms-1.2.jar" />
+			<pathelement location="${opencms.input.libs.runtime}/commons-beanutils-1.8.3.jar" />
+			<pathelement location="${opencms.input.libs.runtime}/commons-collections-3.2.1.jar" />
+			<pathelement location="${opencms.input.libs.runtime}/commons-digester-1.8.jar" />
+			<pathelement location="${opencms.input.libs.runtime}/commons-logging-1.1.1.jar" />
+			<pathelement location="${opencms.input.libs.runtime}/dom4j-1.6.1.jar" />
+			<pathelement location="${opencms.input.libs.runtime}/jug-lgpl-2.0.0.jar" />
+			<pathelement location="${opencms.input.libs.runtime}/xml-apis-2.11-0.jar" />
 		</classpath>
 	</taskdef>
 


### PR DESCRIPTION
The classpaths for the opencms taskdef are outdated and incomplete.
