### PR TITLE
Use ant-opencms.jar instead ant-opencms-1.2.jar

### DIFF
--- a/build-single.xml
+++ b/build-single.xml
@@ -7,6 +7,7 @@
 	<property name="opencms.input.warfiles" location="${opencms.input}/webapp" />
 	<property name="opencms.input.libs.runtime" location="${opencms.input}/lib/runtime" />
 	<property name="opencms.input.libs.compile" location="${opencms.input}/lib/compile" />
+	<property name="opencms.output.jars-components" location="${opencms.output}/build/jars-components" />
 	<property name="opencms.core.lib" location="${opencms.output}/build/jars-core" />
 
 	<property name="module.input" location="${basedir}/${module.name}" />
@@ -36,7 +37,7 @@
 
 	<taskdef resource="org/opencms/util/ant/taskdefs.properties" loaderref="opencms">
 		<classpath>
-			<pathelement location="${opencms.input.libs.compile}/ant-opencms-1.1.jar" />
+			<pathelement location="${opencms.output.jars-components}/ant-opencms.jar" />
 		</classpath>
 	</taskdef>
 

--- a/build.xml
+++ b/build.xml
@@ -4,6 +4,7 @@
 
 	<property name="opencms.input" location="${basedir}/../OpenCms" />
 	<property name="opencms.output" location="${basedir}/../BuildOamp" />
+	<property name="opencms.output.jars-components" location="${opencms.output}/build/jars-components" />
 	<property name="excludes" value="**/CVS/*,**/.cvsignore,**/.nbattrs,**/.project,**/.classpath" />
 	<property name="opencms.output.distfiles" location="${opencms.output}/zip" />
 
@@ -25,7 +26,7 @@
 
 	<taskdef resource="org/opencms/util/ant/taskdefs.properties" loaderref="opencms">
 		<classpath>
-			<pathelement location="${opencms.input}/lib/compile/ant-opencms-1.1.jar" />
+			<pathelement location="${opencms.output.jars-components}/ant-opencms.jar" />
 		</classpath>
 	</taskdef>
 


### PR DESCRIPTION
This change is necessary if applying the patches
https://github.com/gallardo/opencms-core/tree/patch-2 and
https://github.com/gallardo/opencms-core/tree/patch-3 to opencms-core.
