### PR TITLE
Multiple galleries on one page fix.

### DIFF
--- a/com.alkacon.opencms.v8.photoalbum/resources/system/modules/com.alkacon.opencms.v8.photoalbum/formatters/photoalbum.jsp
+++ b/com.alkacon.opencms.v8.photoalbum/resources/system/modules/com.alkacon.opencms.v8.photoalbum/formatters/photoalbum.jsp
@@ -98,6 +98,7 @@
 	<script type='text/javascript'>
      // colorbox configuration
      var colorboxConfig_${albumid} = {
+       rel: '.imagelink_${albumid}',
        close: '<fmt:message key="photoalbum.image.close" />',
        next: '<fmt:message key="photoalbum.image.next" />',
        previous: '<fmt:message key="photoalbum.image.prev" />',
@@ -112,7 +113,7 @@
      // execute on document ready
      $(document).ready(function(){
          // initialize the colorbox for this album
-     	$("a.imagelink_${albumid}").colorbox(colorboxConfig_${albumid});
+     	$(".imagelink_${albumid}").colorbox(colorboxConfig_${albumid});
          // initialize the pagination for this album
      	$("#pagination_${albumid}").pagination(${imageCount},
      	    {


### PR DESCRIPTION
I was having trouble when I had 2 or more galleries on one page. When I tried to view the last image of the first gallery and then "loop over" to the first image, I got to the first image but from the second gallery.

After reading the official documentation of colorbox, I found out that the most simple initialization of colorbox should be:

"$(".group1").colorbox({rel: 'group1'});

As you can see the "rel" attribute is missing, so I added the missing attribute.
Also as you can see there isn't an "a" before the ".group1" so I removed that.

This fixed my problem.

I don't know if that removal of the "a" has any impact on this fix, but I omitted it just to be sure.

Peter Schmiedt
NELASOFT Technologies, s.r.o.
