### PR TITLE
Fix 'DOCTYPE is disallowed' in build script (gradle 2.1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,9 +53,17 @@ modules_oamp_all.split(',').each{ moduleName ->
             gwtModule = moduleProperties['module.gwt']
             gwtSourceSetName = moduleName.replace(".", "_")+'_gwt'
             println "found GWT module $gwtModule"
-            def nonValidatingParser = new XmlParser(false,false,true)
-            nonValidatingParser.getXMLReader().setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-            def moduleXml = nonValidatingParser.parse(srcGwtDir.toString()+"/" +gwtModule.replaceAll('\\.','/')+'.gwt.xml')
+            println "gradle version: " + project.getGradle().getGradleVersion()
+            println "groovy version: " + GroovySystem.getVersion()
+            def xmlParser
+            try { // If groovy constructor available (groovy 2_1_9+, 2_2_0_RC2+), disable feature "load-external-dtd"
+                xmlParser = new XmlParser(false,false,true)
+                xmlParser.getXMLReader().setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+            } catch (e) { // Old groovy parser. No need to disable feature
+                assert e instanceof groovy.lang.GroovyRuntimeException // Could not find matching constructor for: groovy.util.XmlParser(java.lang.Boolean, java.lang.Boolean, java.lang.Boolean)
+                xmlParser = new XmlParser()
+            }
+            def moduleXml = xmlParser.parse(srcGwtDir.toString()+"/" +gwtModule.replaceAll('\\.','/')+'.gwt.xml')
             gwtRename = moduleXml['@rename-to']
             if (gwtRename==null){
                 gwtRename=gwtModule

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,10 @@ modules_oamp_all.split(',').each{ moduleName ->
             gwtModule = moduleProperties['module.gwt']
             gwtSourceSetName = moduleName.replace(".", "_")+'_gwt'
             println "found GWT module $gwtModule"
-            def moduleXml = (new XmlParser()).parse(srcGwtDir.toString()+"/" +gwtModule.replaceAll('\\.','/')+'.gwt.xml')
+            def nonValidatingParser = new XmlParser(false,false,true)
+            nonValidatingParser.getXMLReader().setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+            def nonValidatingParser = new XmlParser(factory.newSAXParser().getXMLReader());
+            def moduleXml = nonValidatingParser.parse(srcGwtDir.toString()+"/" +gwtModule.replaceAll('\\.','/')+'.gwt.xml')
             gwtRename = moduleXml['@rename-to']
             if (gwtRename==null){
                 gwtRename=gwtModule

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,6 @@ modules_oamp_all.split(',').each{ moduleName ->
             println "found GWT module $gwtModule"
             def nonValidatingParser = new XmlParser(false,false,true)
             nonValidatingParser.getXMLReader().setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-            def nonValidatingParser = new XmlParser(factory.newSAXParser().getXMLReader());
             def moduleXml = nonValidatingParser.parse(srcGwtDir.toString()+"/" +gwtModule.replaceAll('\\.','/')+'.gwt.xml')
             gwtRename = moduleXml['@rename-to']
             if (gwtRename==null){


### PR DESCRIPTION
Using gradle 2.1 the build script fails with the following message:

```
[Fatal Error] SerialDateWidget.gwt.xml:2:10: DOCTYPE is disallowed when the feature "http://apache.org/xml/features/disallow-doctype-decl" set to true.
```

The build script uses the default XmlParser. This is 'a non-validating and non-namespace-aware XmlParser which does not allow DOCTYPE declarations in documents'. Correcting it to use a parser that does allow DOCTYPE declarations still tries to fetch an external DTD and fails with a:

```
[Fatal Error] SerialDateWidget.gwt.xml:2:172: External DTD: Failed to read external DTD 'gwt-module.dtd', because 'http' access is not allowed due to restriction set by the accessExternalDTD property.
```

Setting the `load-external-dtd` feature to false fixes the failure.
