### PR TITLE
Workaround #31: dummy implementation of getResults

### DIFF
--- a/com.alkacon.opencms.commons/src/com/alkacon/opencms/commons/CmsConfigurableCollector.java
+++ b/com.alkacon.opencms.commons/src/com/alkacon/opencms/commons/CmsConfigurableCollector.java
@@ -326,4 +326,9 @@ public class CmsConfigurableCollector extends A_CmsResourceCollector {
         return result;
     }
 
+    /** XXX: Workaround <a href="https://github.com/alkacon/alkacon-oamp/issues/31">#31</a> */
+    @Override
+    public List<CmsResource> getResults(CmsObject cms, String collectorName, String params, int numResults) throws CmsException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 }

--- a/com.alkacon.opencms.newsletter/src/com/alkacon/opencms/newsletter/CmsNewsletterResourceCollector.java
+++ b/com.alkacon.opencms.newsletter/src/com/alkacon/opencms/newsletter/CmsNewsletterResourceCollector.java
@@ -195,4 +195,10 @@ public class CmsNewsletterResourceCollector extends A_CmsResourceCollector {
 
         return shrinkToFit(result, data.getCount());
     }
+
+    /** XXX: Workaround <a href="https://github.com/alkacon/alkacon-oamp/issues/31">#31</a> */
+    @Override
+    public List<CmsResource> getResults(CmsObject cms, String collectorName, String params, int numResults) throws CmsException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 }

--- a/com.alkacon.opencms.v8.newsletter/src/com/alkacon/opencms/v8/newsletter/CmsNewsletterResourceCollector.java
+++ b/com.alkacon.opencms.v8.newsletter/src/com/alkacon/opencms/v8/newsletter/CmsNewsletterResourceCollector.java
@@ -195,4 +195,10 @@ public class CmsNewsletterResourceCollector extends A_CmsResourceCollector {
 
         return shrinkToFit(result, data.getCount());
     }
+
+    /** XXX: Workaround <a href="https://github.com/alkacon/alkacon-oamp/issues/31">#31</a> */
+    @Override
+    public List<CmsResource> getResults(CmsObject cms, String collectorName, String params, int numResults) throws CmsException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 }


### PR DESCRIPTION
opencms-core has extended interface I_CmsResourceCollector with a new
method signature. This commit is a workaround to allow compiling the
outdated alkacon-oamp sources.
