### PR TITLE
Workaround mangled javadocs (java 8+)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -313,12 +313,12 @@ install {
             }
         }
     }
-    
-    if (JavaVersion.current().isJava8Compatible()) {
-        allprojects {
-            tasks.withType(Javadoc) {
-                failOnError = false
-            }
-        }
-    }    
 }
+
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+        tasks.withType(Javadoc) {
+            failOnError = false
+        }
+    }
+}    

--- a/build.gradle
+++ b/build.gradle
@@ -313,4 +313,12 @@ install {
             }
         }
     }
+    
+    if (JavaVersion.current().isJava8Compatible()) {
+        allprojects {
+            tasks.withType(Javadoc) {
+                failOnError = false
+            }
+        }
+    }    
 }


### PR DESCRIPTION
With Java 8, the build fails with the message `Execution failed for task ':javadoc_com.alkacon.opencms.calendar'`. This patch ignores javadoc errors during the build for Java 8+.

Log follows (warnings skipped):

```
[...]/alkacon-oamp/com.alkacon.opencms.calendar/src/com/alkacon/opencms/calendar/CmsSerialDateSelectWidget.java:64: error: unknown tag: layout
 * <code><layout element="Change" widget="SerialDateSelectWidget" configuration="property:calendar.startdate|count:25" /></code>.<p>
         ^

[...]
:javadoc_com.alkacon.opencms.calendar
1 error
22 warnings
:javadoc_com.alkacon.opencms.calendar FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':javadoc_com.alkacon.opencms.calendar'.
```
