### PR TITLE
Fix incompatible types error (Java 8+)

### DIFF
--- a/com.alkacon.opencms.v8.comments/src/com/alkacon/opencms/v8/comments/CmsCommentsAccess.java
+++ b/com.alkacon.opencms.v8.comments/src/com/alkacon/opencms/v8/comments/CmsCommentsAccess.java
@@ -1016,7 +1016,9 @@ public class CmsCommentsAccess extends CmsJspLoginBean {
     private void initConfig(PageContext context, HttpServletRequest req, HttpServletResponse res) {
 
         if (LOG.isDebugEnabled()) {
-            for (Map.Entry<String, String[]> entry : CmsRequestUtil.createParameterMap(req.getParameterMap()).entrySet()) {
+            @SuppressWarnings("unchecked")
+            Map<String, ?> reqParam = req.getParameterMap();
+            for (Map.Entry<String, String[]> entry : CmsRequestUtil.createParameterMap(reqParam).entrySet()) {
                 LOG.debug(Messages.get().getBundle().key(
                     Messages.LOG_INIT_PARAM_2,
                     entry.getKey(),


### PR DESCRIPTION
With Java 8 the compilation breaks with an "incompatible types" error.

Error log follows:

```
alkacon-oamp/com.alkacon.opencms.v8.comments/src/com/alkacon/opencms/v8/comments/CmsCommentsAccess.java:1019: error: incompatible types: Object cannot be converted to Entry<String,String[]>
            for (Map.Entry<String, String[]> entry : CmsRequestUtil.createParameterMap(req.getParameterMap()).entrySet()) {
                                                                                                                      ^
Note: [...]/alkacon-oamp/com.alkacon.opencms.v8.comments/src/com/alkacon/opencms/v8/comments/CmsCommentsAccess.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 error
:compileComAlkaconOpencmsV8CommentsJava FAILED
```
