### PR TITLE
[WIP!] - Add acacia-editor-client dependency

### DIFF
--- a/com.alkacon.opencms.v8.calendar/src/com/alkacon/opencms/v8/calendar/client/widget/CmsSerialDateSelectWidget.java
+++ b/com.alkacon.opencms.v8.calendar/src/com/alkacon/opencms/v8/calendar/client/widget/CmsSerialDateSelectWidget.java
@@ -33,7 +33,7 @@ import com.alkacon.vie.client.Entity;
 
 import org.opencms.ade.contenteditor.client.CmsContentEditor;
 import org.opencms.ade.contenteditor.client.I_CmsEntityChangeListener;
-import org.opencms.ade.contenteditor.client.widgets.CmsSelectWidget;
+import org.opencms.acacia.client.client.widgets.CmsSelectWidget;
 import org.opencms.ade.contenteditor.shared.CmsContentDefinition;
 import org.opencms.gwt.client.CmsCoreProvider;
 import org.opencms.gwt.client.rpc.CmsRpcAction;

--- a/com.alkacon.opencms.v8.calendar/src/com/alkacon/opencms/v8/calendar/client/widget/CmsSerialDateSelectWidget.java
+++ b/com.alkacon.opencms.v8.calendar/src/com/alkacon/opencms/v8/calendar/client/widget/CmsSerialDateSelectWidget.java
@@ -33,7 +33,7 @@ import com.alkacon.vie.client.Entity;
 
 import org.opencms.ade.contenteditor.client.CmsContentEditor;
 import org.opencms.ade.contenteditor.client.I_CmsEntityChangeListener;
-import org.opencms.acacia.client.client.widgets.CmsSelectWidget;
+import org.opencms.acacia.client.widgets.CmsSelectWidget;
 import org.opencms.ade.contenteditor.shared.CmsContentDefinition;
 import org.opencms.gwt.client.CmsCoreProvider;
 import org.opencms.gwt.client.rpc.CmsRpcAction;

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -13,6 +13,9 @@ dependencies {
     compile group: 'org.opencms', name: 'org.opencms.workplace.tools.modules', version: opencms_version
     compile group: 'org.opencms', name: 'org.opencms.workplace.tools.sites', version: opencms_version
 
+     // required by :compileCom_alkacon_opencms_v8_calendar_gwtJava
+    compile group: 'com.alkacon', name: 'acacia-editor-client', version: '3.0'
+    
     // used in old an v8 version of the modules
     compile files('com.alkacon.opencms.counter/resources/system/modules/com.alkacon.opencms.counter/lib/com.alkacon.opencms.util.jar')
     compile files('com.alkacon.opencms.feeder/resources/system/modules/com.alkacon.opencms.feeder/lib/jdom-1.0.jar')


### PR DESCRIPTION
The task `:compileCom_alkacon_opencms_v8_calendar_gwtJava` fails with 18 errors (`package com.alkacon.acacia.client.widgets does not exist`).

An excerpt from the output follows:

```
alkacon-oamp/com.alkacon.opencms.v8.calendar/src/com/alkacon/opencms/v8/calendar/client/widget/CmsSerialDateWidgetFactory.java:30: error: package com.alkacon.acacia.client.widgets does not exist
import com.alkacon.acacia.client.widgets.FormWidgetWrapper;
                                        ^
[...]
alkacon-oamp/com.alkacon.opencms.v8.calendar/src/com/alkacon/opencms/v8/calendar/client/widget/css/I_CmsLayoutBundle.java:40: error: cannot find symbol
    interface I_CmsWidgetCss extends I_Widgets {
                                     ^
  symbol:   class I_Widgets
  location: interface I_CmsLayoutBundle
18 errors
:compileCom_alkacon_opencms_v8_calendar_gwtJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileCom_alkacon_opencms_v8_calendar_gwtJava'.
```
