### PR TITLE
build: fix Cannot convert the provided notation...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,7 +168,7 @@ modules_oamp_all.split(',').each{ moduleName ->
                 // to clean the output directory, delete it first
                 def dir = file(buildDir)
                 if (dir.exists()){
-                    delete{ delete dir }
+                    delete dir
                 }
                 dir.mkdirs()
             }


### PR DESCRIPTION
Following error is thrown during the gwt_ build:

Execution failed for task ':gwt_com.alkacon.opencms.v8.calendar'.

> Cannot convert the provided notation to a File or URI: true.
>   The following types/formats are supported:
>     - A String or CharSequence path, e.g 'src/main/java' or '/usr/include'
>     - A String or CharSequence URI, e.g 'file:/usr/include'
>     - A File instance.
>     - A URI or URL instance.
