### PR TITLE
Workaround JavaDoc errors (alternative to PR34)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -263,6 +263,14 @@ tasks.findAll{ task -> task.name.startsWith('dist_')}.each{ dist_task ->
 tasks.withType(JavaCompile) {
     options.compilerArgs += ["-sourcepath", ""]
 }
+
+tasks.withType(Javadoc) {
+    options.addStringOption("sourcepath", "")
+    if (JavaVersion.current().isJava8Compatible()) {
+        options.addStringOption("Xdoclint:none", "-quiet")
+    } 
+}
+
 artifacts {
     tasks.each{ task ->
         if (task.name.startsWith("jar_com.alkacon.")){
@@ -318,3 +326,4 @@ install {
         }
     }
 }
+


### PR DESCRIPTION
Alternative to https://github.com/alkacon/alkacon-oamp/pull/34, in line with https://github.com/dSeidel 's commit https://github.com/alkacon/opencms-core/commit/b244656ed3a0337dca6f73e7d9824e80b57284f4
