### PR TITLE
Add missing captcha config id to text captcha

### DIFF
--- a/com.alkacon.opencms.v8.formgenerator/src/com/alkacon/opencms/v8/formgenerator/CmsCaptchaField.java
+++ b/com.alkacon.opencms.v8.formgenerator/src/com/alkacon/opencms/v8/formgenerator/CmsCaptchaField.java
@@ -141,7 +141,7 @@ public class CmsCaptchaField extends A_CmsField {
                 formHandler.getCmsObject());
             captchaHtml.append("<div style=\"margin: 0 0 2px 0;\">");
             captchaHtml.append(service.getTextChallengeForID(
-                sessionId,
+                sessionId + m_captchaSettings.getConfigId(),
                 formHandler.getCmsObject().getRequestContext().getLocale()));
             captchaHtml.append("</div>\n");
         } else {


### PR DESCRIPTION
The text captcha is generated with the session id but the validation method compares the id of this captcha with the session id + config id. Thats the reason why the math captcha throws an error even if the user submits the right result.